### PR TITLE
añadida actualización de la lista al realizar cambios -> Flow

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     def coroutines_version = '1.6.4'
     def lifecycle_version = "2.6.0-alpha03"
     def nav_version = "2.5.3"
+    def datastore_version = "1.0.0"
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
@@ -56,7 +57,8 @@ dependencies {
     // VIEWMODEL AND LIVEDATA
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
-
+    // DATASTORE
+    implementation "androidx.datastore:datastore-preferences:$datastore_version"
     // FRAGMENTS AND NAVIGATION
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/data/RssDataRepository.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/data/RssDataRepository.kt
@@ -1,13 +1,27 @@
 package com.rafaelmardom.pruebarss.management.data
 
+import com.rafaelmardom.pruebarss.management.data.local.datastore.RssDataStore
 import com.rafaelmardom.pruebarss.management.data.local.xml.RssXmlLocalDataSource
 import com.rafaelmardom.pruebarss.management.domain.DomainRss
 import com.rafaelmardom.pruebarss.management.domain.DomainRssRepository
+import kotlinx.coroutines.flow.Flow
 
 class RssDataRepository (
-    private val localSource: RssXmlLocalDataSource
+//    private val localSource: RssXmlLocalDataSource
+    private val localSource: RssDataStore
 ): DomainRssRepository{
+    override suspend fun save(website: String, url: String) {
+        localSource.save(website, url)
+    }
 
+    override suspend fun getAll(): Flow<List<DomainRss>> {
+        return localSource.getAll()
+    }
+
+    override suspend fun delete(url: String){
+        localSource.delete(url)
+    }
+    /*
     override fun save(website: String, url: String) {
         localSource.save(website, url)
     }
@@ -17,5 +31,6 @@ class RssDataRepository (
     }
 
     override fun delete(url: String): Boolean = localSource.delete(url)
+     */
 
 }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/data/local/datastore/RssDataStore.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/data/local/datastore/RssDataStore.kt
@@ -1,0 +1,41 @@
+package com.rafaelmardom.pruebarss.management.data.local.datastore
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.google.gson.Gson
+import com.rafaelmardom.pruebarss.management.domain.DomainRss
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore by preferencesDataStore(
+    name = "rss_datastore"
+)
+
+class RssDataStore (private val context: Context){
+
+    private val gson = Gson()
+
+    suspend fun save(website:String , url: String) {
+        context.dataStore.edit {
+            it[stringPreferencesKey(url)] = gson.toJson(DomainRss(website, url), DomainRss::class.java)
+        }
+    }
+
+    fun getAll(): Flow<List<DomainRss>> {
+        return context.dataStore.data
+            .map {
+                it.asMap().values.map { json ->
+                    gson.fromJson(json as String, DomainRss::class.java)
+                }
+            }
+    }
+
+    suspend fun delete(url: String){
+        context.dataStore.edit {
+            it.remove(stringPreferencesKey(url))
+        }
+    }
+
+}

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/DeleteRssUseCase.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/DeleteRssUseCase.kt
@@ -3,5 +3,8 @@ package com.rafaelmardom.pruebarss.management.domain
 class DeleteRssUseCase(
     private val domainRssRepository: DomainRssRepository
 ) {
-    fun execute (url:String): Boolean = domainRssRepository.delete(url)
+    suspend fun execute (url:String){
+        domainRssRepository.delete(url)
+    }
+    //fun execute (url:String): Boolean = domainRssRepository.delete(url)
 }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/DomainRssRepository.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/DomainRssRepository.kt
@@ -1,7 +1,14 @@
 package com.rafaelmardom.pruebarss.management.domain
 
+import kotlinx.coroutines.flow.Flow
+
 interface DomainRssRepository {
+    suspend fun save(website:String, url:String)
+    suspend fun getAll(): Flow<List<DomainRss>>
+    suspend fun delete(url:String)
+    /*
     fun save(website:String, url:String)
     fun getAll(): List<DomainRss>
     fun delete(url:String): Boolean
+     */
 }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/GetRssSourceUseCase.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/GetRssSourceUseCase.kt
@@ -1,8 +1,14 @@
 package com.rafaelmardom.pruebarss.management.domain
 
+import kotlinx.coroutines.flow.Flow
+
 class GetRssSourceUseCase(
     private val domainRssRepository: DomainRssRepository
 ) {
+    suspend fun execute(): Flow<List<DomainRss>> {
+        return domainRssRepository.getAll()
+    }
+    /*
     fun execute (): List<RssManagement> {
         return domainRssRepository.getAll().map {
             RssManagement(
@@ -16,4 +22,5 @@ class GetRssSourceUseCase(
         val website: String,
         val url: String
     )
+     */
 }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/SaveRssUseCase.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/domain/SaveRssUseCase.kt
@@ -3,7 +3,12 @@ package com.rafaelmardom.pruebarss.management.domain
 class SaveRssUseCase(
     private val domainRssRepository: DomainRssRepository
 ) {
+    suspend fun execute (website:String, url:String) {
+        domainRssRepository.save(website, url)
+    }
+    /*
     fun execute (website:String, url:String) {
         domainRssRepository.save(website, url)
     }
+     */
 }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/AddRssBottomSheetFragment.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/AddRssBottomSheetFragment.kt
@@ -19,8 +19,9 @@ class AddRssBottomSheetFragment : BottomSheetDialogFragment() {
     val viewModel by lazy {
         this.activity?.let {
             ManagementFactory().saveRss(
-                    it.getSharedPreferences("rssLocal", MODE_PRIVATE),
-                )
+                // it.getSharedPreferences("rssLocal", MODE_PRIVATE),
+                this.requireContext()
+            )
         }
     }
 

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/ManagementFactory.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/ManagementFactory.kt
@@ -3,12 +3,21 @@ package com.rafaelmardom.pruebarss.management.presentation
 import android.content.Context
 import android.content.SharedPreferences
 import com.rafaelmardom.pruebarss.management.data.RssDataRepository
+import com.rafaelmardom.pruebarss.management.data.local.datastore.RssDataStore
 import com.rafaelmardom.pruebarss.management.data.local.xml.RssXmlLocalDataSource
 import com.rafaelmardom.pruebarss.management.domain.DeleteRssUseCase
 import com.rafaelmardom.pruebarss.management.domain.GetRssSourceUseCase
 import com.rafaelmardom.pruebarss.management.domain.SaveRssUseCase
 
 class ManagementFactory {
+    fun saveRss(context: Context): ManagementViewModel {
+        return ManagementViewModel(
+            SaveRssUseCase(
+                getRssRepository(context)
+            )
+        )
+    }
+    /*
     fun saveRss(sharedPreferences: SharedPreferences): ManagementViewModel {
         return ManagementViewModel(
             SaveRssUseCase(
@@ -20,6 +29,7 @@ class ManagementFactory {
             )
         )
     }
+     */
     // MANAGEMENT
     fun getRssManagementViewModel(applicationContext: Context) : RssManagementViewModel{
         return RssManagementViewModel(
@@ -42,9 +52,18 @@ class ManagementFactory {
     //
     private fun getRssRepository(context: Context): RssDataRepository {
         return RssDataRepository(
+            RssDataStore(
+                context
+            )
+        )
+    }
+    /*
+    private fun getRssRepository(context: Context): RssDataRepository {
+        return RssDataRepository(
             RssXmlLocalDataSource(
                 context.getSharedPreferences("rssLocal", Context.MODE_PRIVATE)
             )
         )
     }
+     */
 }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/ManagementFragment.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/ManagementFragment.kt
@@ -65,7 +65,7 @@ class ManagementFragment : Fragment() {
 
     private fun setupObservers(){
         val rssState = Observer<RssManagementViewModel.ManagementUiState> {
-            rssAdapter.setDataItems(it.rssManagement)
+            it.rssManagement?.let { it1 -> rssAdapter.setDataItems(it1) }
         }
         viewModel.managementPublisher.observe(viewLifecycleOwner, rssState)
     }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/ManagementViewModel.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/ManagementViewModel.kt
@@ -16,6 +16,10 @@ class ManagementViewModel (
     }
 
     fun saveRss(website:String, url:String){
+        viewModelScope.launch {
+            saveRssUseCase.execute(website, url)
+        }
+        /*
         managementPublisher.value = ManagementUiState(true)
 
         viewModelScope.launch(Dispatchers.IO){
@@ -26,6 +30,7 @@ class ManagementViewModel (
                 )
             )
         }
+         */
     }
 
     data class ManagementUiState(

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/RssManagementViewModel.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/RssManagementViewModel.kt
@@ -1,9 +1,11 @@
 package com.rafaelmardom.pruebarss.management.presentation
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rafaelmardom.pruebarss.management.domain.DeleteRssUseCase
+import com.rafaelmardom.pruebarss.management.domain.DomainRss
 import com.rafaelmardom.pruebarss.management.domain.GetRssSourceUseCase
 import com.rafaelmardom.pruebarss.management.domain.SaveRssUseCase
 import kotlinx.coroutines.Dispatchers
@@ -14,11 +16,28 @@ class RssManagementViewModel (
     private val deleteRssUseCase: DeleteRssUseCase
 ) : ViewModel() {
 
+
+    private val _managementPublisher = MutableLiveData(ManagementUiState())
+    val managementPublisher: LiveData<ManagementUiState> = _managementPublisher
+
+    /*
     val managementPublisher: MutableLiveData<ManagementUiState> by lazy {
         MutableLiveData<ManagementUiState>()
     }
+     */
 
     fun loadRss(){
+        viewModelScope.launch {
+            getRssSourceUseCase.execute()
+                .collect { domainRss ->
+                    _managementPublisher.postValue(
+                        ManagementUiState(
+                            domainRss
+                        )
+                    )
+                }
+        }
+        /*
         managementPublisher.value = ManagementUiState()
 
         viewModelScope.launch(Dispatchers.IO) {
@@ -29,16 +48,23 @@ class RssManagementViewModel (
                 ),
             )
         }
+         */
     }
 
     fun deleteRss(url:String){
+        viewModelScope.launch{
+            deleteRssUseCase.execute(url)
+        }
+        /*
         viewModelScope.launch (Dispatchers.IO){
             deleteRssUseCase.execute(url)
         }
+         */
     }
 
     data class ManagementUiState(
-        val rssManagement: List<GetRssSourceUseCase.RssManagement> = emptyList()
+        val rssManagement: List<DomainRss>? = null
+        // val rssManagement: List<GetRssSourceUseCase> = emptyList()
     )
 
 }

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/adapter/RssAdapter.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/adapter/RssAdapter.kt
@@ -5,18 +5,20 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.rafaelmardom.pruebarss.R
+import com.rafaelmardom.pruebarss.management.domain.DomainRss
 import com.rafaelmardom.pruebarss.management.domain.GetRssSourceUseCase
 
-class RssAdapter: RecyclerView.Adapter<RssManagementViewHolder>() {
+class RssAdapter : RecyclerView.Adapter<RssManagementViewHolder>()
+{
+    private val dataItems = mutableListOf<DomainRss>()
+    //private val dataItems = mutableListOf<GetRssSourceUseCase.RssManagement>()
+    var itemClick: ((String) -> Unit)? = null
 
-    private val dataItems = mutableListOf<GetRssSourceUseCase.RssManagement>()
-    var itemClick: ((String) -> Unit)? =null
-
-    fun setOnClick(itemClick :(String) -> Unit){
+    fun setOnClick(itemClick: (String) -> Unit) {
         this.itemClick = itemClick
     }
 
-    fun setDataItems(movies: List<GetRssSourceUseCase.RssManagement>) {
+    fun setDataItems(movies: List<DomainRss>/*List<GetRssSourceUseCase.RssManagement>*/) {
         dataItems.clear()
         dataItems.addAll(movies)
         notifyDataSetChanged()

--- a/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/adapter/RssManagementViewHolder.kt
+++ b/app/src/main/java/com/rafaelmardom/pruebarss/management/presentation/adapter/RssManagementViewHolder.kt
@@ -3,13 +3,15 @@ package com.rafaelmardom.pruebarss.management.presentation.adapter
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import com.rafaelmardom.pruebarss.databinding.ViewItemRssManagementBinding
+import com.rafaelmardom.pruebarss.management.domain.DomainRss
 import com.rafaelmardom.pruebarss.management.domain.GetRssSourceUseCase
 
 class RssManagementViewHolder (
     private val view: View
 ): RecyclerView.ViewHolder( view ){
     fun bind (
-        rss: GetRssSourceUseCase.RssManagement,
+        rss: DomainRss,
+//        rss: GetRssSourceUseCase.RssManagement,
         itemClick: ((String) -> Unit?)?
     ){
         val binding = ViewItemRssManagementBinding.bind(view)


### PR DESCRIPTION
## Description de la tarea
<!-- Descripción sobre lo que se pide en la tarea -->
Actualizar el listado de RSS a medida que voy añadiendo o eliminando información.

## ¿Cómo se ha implementado?
<!-- Estructura de clases, patrones: MVVM, etc.  -->
> Esta PR es MUY extensa, por eso confío en ti @Joelgh1 para revisarla porque eres un crack y seguro que me ayudas.

_**Primero y más importante**_:
He tenido que reestructurar casi todas la capas de domain, presentation y data para poder implementar DataStore. He dejado comentado prácticamente todo lo que he tocado, pero eliminaré todos los archivos y comentarios innecesarios una vez se apruebe la PR y realizados todos los cambios sugeridos.

Esencial y como es de suponer, se ha añadido la correspondiente librería para implementar DataStore.

Intentaré explicar los cambios en orden:
**DOMAIN**
1. DomainRssRepository:
- Ahora todas las funciones pasan a ser suspendidas.
- La función getAll() devuelve un objeto Flow con la lista de Rss.
- La función delete() ya no devuelve un booleano.

2. [X]UseCase:
- las funciones execute() ahora son suspendidas.
- En el caso de GetRssSourceUseCase, se ha eliminado la data class RssManagement debido a que no he sido capaz de lograr un parseo de la lista. Esto a provocado varios cambios en presentation.

**LOCAL**
3. datastore > RssDataStore:
- Nuevo fichero creado para implementar DataStore. Recibe Context por parámetro e implementa la librería de serialización de gson (Json <-> Object) para parsear Objetos DomainRss a Json, ya que DataStore trabaja con este tipo de ficheros.
- Este archivo dispone de una variable de estado que crea una instancia de DataStore y nos permite tratarla como un singleton en toda la App.
> Este archivo debería reemplazar a la interfaz RssLocalDataSource y a la clase RssXmlLocalDataSource, ya que no volverán a usarse en la aplicación.

4. RssDataRepository
- Ya NO se construye con una fuente local (RssXmlLocalDataStore), sino con la clase RssDataStore que hemos creado, y sigue heredando de DomainRssRepository (por ello los cambios en domain).
- Simplemente sirve para llamar a las funciones de RssDataStore.

**PRESENTATION**
5. ManagementFactory:
- La función getRssRepository() ahora devuelve un RssDataRepository creado con RssDataStore (como es necesario).
- La función saveRss() ahora está estructurada igual que el resto de funciones que llaman a un UseCase
> DE HECHO, he visto que tiene un naming incorrecto, porque debería llamarse algo entre las líneas de "getManagementViewModel()" ya que es lo que devuelve (?) me he dado cuenta al escribir la PR así que probablemente aproveche para cambiarlo. De la misma manera, no sé por qué no existe la función getSaveUseCase(). También será añadida.

6. AddRssBottomSheetFragment:
- Únicamente se ha cambiado el constructor del viewModel, ya que ahora requiere Context no sharedPrefs.

7. ManagementViewModel:
- Se ha añadido _managementPublisher como una lista de datos privada, de forma que no se pueda acceder a ella y modificarla desde otras clases. A cambio, se crea managementPublisher como una lista estática LiveData que se actualiza con la info de la lista privada.
- Para que lo anteriormente mencionado funcionara, ManagementUiState que es la data class del fragmento con la lista de Rss mostrados en el recyclerView, es ahora una Lista de DomainRss, en lugar de GetRssSourceUseCase, ya que ese caso de uso ahora devuelve Flow.
> Creo que podría ser una lista de Flow<List<DomainRss>> pero no lo he comprobado ni sé si sería redundante.
- Se actualizan las funciones deleteRss() y loadRss(), ya no se ejecutan en el hilo IO.

8. ManagementViewModel:
- Editada la función saveRss(), de forma que ya no se ejecuta en el hilo IO.
> Creo que todo el código funcional de esta clase puede ser transportado a RssManagementViewModel y/o viceversa, ya que son muy parecidas y entiendo que funcionaría igual.

9. ManagementFragment:
- Aquí he tenido que hacer un cambio en setupObservers() que, exactamente no sé que hace. Entiendo que lo que hace es refrescar la lista con cada cambio en DataStore. El cambio ha sido aplicado automáticamente con la recomendación de Android Studio.

10. adapter > RssAdapter:
- dataItems ahora es una mutableListOf<DomainRss> ya que ahora la lista recibida no es de la data class del caso de uso, sino directamente DomainRss.

11. adapter > RssManagementViewHolder:
- El constructor ahora recibe una DomainRss por parámetro, por el mismo motivo que la lista mutable del adapter.

> ¿Lo bueno? La funcionalidad de la App no ha variado. ¿Lo malo? Dudo que pasar la data class de domain sea buenas prácticas. T_T

## Keywords
<!-- Palabras relacionadas con los conceptos vistos -->
DataStore, Flow, UseCase, ViewModel, Fragment, Repository, etc etc.

## Screenshots or Video
<!-- Captura de pantalla de la consola -->

https://user-images.githubusercontent.com/104196849/208731275-d6cd036d-bd4b-490e-b99e-55e9a85ed81d.mp4

